### PR TITLE
fix spelling so when I also misspell Python

### DIFF
--- a/doc/01_actions_script.md
+++ b/doc/01_actions_script.md
@@ -1,4 +1,4 @@
-# Convert exiting Pythong script into a StackStorm action
+# Convert exiting Python script into a StackStorm action
 
 For our first action we're going to convert an existing python script into a
 StackStorm action. Our existing python script lives in [etc/nasa_apod.py](etc/nasa_apod.py). 


### PR DESCRIPTION
fix spelling so when I also misspell Python, I don't get a hit for `Pythong`